### PR TITLE
Fix GameContext score setup

### DIFF
--- a/context/game_context.py
+++ b/context/game_context.py
@@ -13,8 +13,9 @@ class GameContext:
         self.train_deck = TrainCardDeck()
         self.ticket_deck = TicketDeck()
         self.turn_num = 0
-        for p in player_ids:
-            self.scores = {p: 0 for p in player_ids}
+        # initialize score dictionary for all players
+        # each player starts with a score of 0
+        self.scores = {p: 0 for p in player_ids}
 
 
     def set_score(self,player_id,score):


### PR DESCRIPTION
## Summary
- fix initialization of `GameContext.scores` so all players start with score 0

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py <<'EOF'
2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687bda07aae88329b5c1a7dd9391e72a